### PR TITLE
fix(docker): Pin clamav package version

### DIFF
--- a/docker/Dockerfile-clamd
+++ b/docker/Dockerfile-clamd
@@ -1,9 +1,11 @@
+ARG CLAMAV_VERSION=1.0.7
 FROM python:3.12-bookworm@sha256:0910192fc5ae576a3301ba3c296bbceae563d69dda5e09c4b26c522130ce101c
 
 WORKDIR /app
 
 # install system dependencies (clamd, freshclam)
-RUN apt update && apt install -y clamav-daemon
+RUN apt update && apt install -y \
+    clamav-daemon=${CLAMAV_VERSION}*
 
 # install python tooling (poetry)
 RUN pip install --no-cache-dir poetry==2.0.1


### PR DESCRIPTION
Pin `clamav-daemon` Debian package version in bundled Docker mode.