### PR TITLE
feat(clamd): Allow explicit schedule of db refreshes

### DIFF
--- a/docker/Dockerfile-clamd
+++ b/docker/Dockerfile-clamd
@@ -7,6 +7,16 @@ WORKDIR /app
 RUN apt update && apt install -y \
     clamav-daemon=${CLAMAV_VERSION}*
 
+# install supercronic (see https://github.com/aptible/supercronic/releases)
+ENV SUPERCRONIC_URL=https://github.com/aptible/supercronic/releases/download/v0.2.42/supercronic-linux-amd64 \
+    SUPERCRONIC_SHA1SUM=b444932b81583b7860849f59fdb921217572ece2 \
+    SUPERCRONIC=supercronic-linux-amd64
+RUN curl -fsSLO "$SUPERCRONIC_URL" \
+ && echo "${SUPERCRONIC_SHA1SUM}  ${SUPERCRONIC}" | sha1sum -c - \
+ && chmod +x "$SUPERCRONIC" \
+ && mv "$SUPERCRONIC" "/usr/local/bin/${SUPERCRONIC}" \
+ && ln -s "/usr/local/bin/${SUPERCRONIC}" /usr/local/bin/supercronic
+
 # install python tooling (poetry)
 RUN pip install --no-cache-dir poetry==2.0.1
 
@@ -32,8 +42,7 @@ RUN mkdir -p /var/log/clamav /var/lib/clamav /var/run/clamav && \
 
 # default configuration
 ENV CLAMAV_CLAMD_SOCKET_PATH=/var/run/clamav/clamd.sock
-ENV CLAMAV_FRESHCLAM_DAILY_CHECKS=1440
-
+ENV CLAMAV_DB_REFRESH_CRON="0 4 * * *"
 EXPOSE 80
 
 # do not run as root. this user is created by the clamav debian package

--- a/docker/clamav/freshclam.conf
+++ b/docker/clamav/freshclam.conf
@@ -17,7 +17,7 @@ ScriptedUpdates yes
 CompressLocalDatabase no
 Bytecode true
 NotifyClamd /etc/clamav/clamd.conf
-# Check for new database once a day
-Checks 1
+# never check for new database. we won't use daemon mode but an explicit cron
+Checks 0
 DatabaseMirror db.local.clamav.net
 DatabaseMirror database.clamav.net

--- a/docker/clamd-entrypoint.sh
+++ b/docker/clamd-entrypoint.sh
@@ -6,13 +6,21 @@
 set -e
 
 # redirect daemons output to stderr
-tail --pid 1 -n0 -F /var/log/clamav/clamd.log /var/log/clamav/freshclam.log > /dev/stderr &
+clamd_log=/var/log/clamav/clamd.log
+freshclam_log=/var/log/clamav/freshclam.log
+touch $clamd_log $freshclam_log
+tail --pid 1 -n0 -F $clamd_log $freshclam_log > /dev/stderr &
 
 # update antivirus database
 freshclam
 # start the clamav daemon
 clamd
-# start the freshclam daemon to keep automated updates
-freshclam -d
+
+# start supercronic for scheduled freshclam updates. we don't start
+# freshclam -d because you can't configure the timing correctly, you
+# can just specify how many times a day. we want a real cron here.
+echo "${CLAMAV_DB_REFRESH_CRON} /usr/bin/freshclam >> $freshclam_log 2>&1" > /tmp/freshclam-cron
+supercronic /tmp/freshclam-cron &
 
 exec "$@"
+


### PR DESCRIPTION
This PR impacts only the clamd bundled image (`Dockerfile-clamd`) and not the application per-se.

Replace freshclam daemon `freshclam -d` for refreshing antivirus database with a predictable cron job running `freshclam` on a schedule.

This is needed to be able to set a schedule for refreshes: in fact, freshclam daemon allows only configuring a refresh "frequency" (how many time to refresh a day) but not to set a fully fledged schedule. 

Considering that refreshes could cause spikes in memory usage (despite the option `ConcurrentDatabaseReload false` that should avoid doubling memory usage) we should be able to predictably run the refresh on a schedule, probably in off-peak hours.

As a sidenote, Supercronic is used instead of regular cron because we don't want to run container as root (as it is needed by cron).