### PR TITLE
feat(clamd): Testing mode for clamd bundled image

### DIFF
--- a/docker/Dockerfile-clamd
+++ b/docker/Dockerfile-clamd
@@ -43,6 +43,13 @@ RUN mkdir -p /var/log/clamav /var/lib/clamav /var/run/clamav && \
 # default configuration
 ENV CLAMAV_CLAMD_SOCKET_PATH=/var/run/clamav/clamd.sock
 ENV CLAMAV_DB_REFRESH_CRON="0 4 * * *"
+# set test mode off by default.
+# WARNING this is unsafe only for testing environments!
+# it will cause the signature db to be replaced with a
+# fake db with single entry for eicar test file. this
+# allows a testing environment without high memory usage
+# (clamd loads the whole signature db in memory)
+ENV CLAMAV_TEST_MODE=false
 EXPOSE 80
 
 # do not run as root. this user is created by the clamav debian package

--- a/docker/clamd-entrypoint.sh
+++ b/docker/clamd-entrypoint.sh
@@ -11,16 +11,25 @@ freshclam_log=/var/log/clamav/freshclam.log
 touch $clamd_log $freshclam_log
 tail --pid 1 -n0 -F $clamd_log $freshclam_log > /dev/stderr &
 
-# update antivirus database
-freshclam
+# handle test mode vs production database
+if [ "$CLAMAV_TEST_MODE" = "true" ]; then
+    # create minimal eicar-only database.  this will greatly reduce
+    # memory usage in testing environments but will just recognize the
+    # EICAR test file as virus
+    echo "44d88612fea8a8f36de82e1278abb02f:68:EICAR-Test-Signature" > /var/lib/clamav/test.hdb
+    echo "WARNING: Running in TEST MODE. Minimal signatures loaded, DO NOT USE IN PRODUCTION"
+else
+    # update antivirus database
+    freshclam
+
+    # start supercronic for scheduled freshclam updates. we don't start
+    # freshclam -d because you can't configure the timing correctly, you
+    # can just specify how many times a day. we want a real cron here.
+    echo "${CLAMAV_DB_REFRESH_CRON} /usr/bin/freshclam >> $freshclam_log 2>&1" > /tmp/freshclam-cron
+    supercronic /tmp/freshclam-cron &
+fi
+
 # start the clamav daemon
 clamd
 
-# start supercronic for scheduled freshclam updates. we don't start
-# freshclam -d because you can't configure the timing correctly, you
-# can just specify how many times a day. we want a real cron here.
-echo "${CLAMAV_DB_REFRESH_CRON} /usr/bin/freshclam >> $freshclam_log 2>&1" > /tmp/freshclam-cron
-supercronic /tmp/freshclam-cron &
-
 exec "$@"
-


### PR DESCRIPTION
This PR impacts only the clamd bundled image (`Dockerfile-clamd`) and not the application per-se.

Add a testing mode for testing environment only in which signature databases are not managed and udpated by freshclam with real-world signatures, but only the signature of EICAR test file is manually added.

This allows to greatly reduce memory usage in testing environments: in fact, the signature db is loaded in memory and is about 700MB-1.2GB, which we can consider too much for an environment where we just want to test with EICAR most of the times.