### PR TITLE
chore: Fix Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,4 +1,7 @@
 name: "Validate PR title"
+permissions:
+  contents: read
+  pull-requests: read
 
 on:
   pull_request_target:


### PR DESCRIPTION
Potential fix for [https://github.com/pagopa/clamav-rest-service/security/code-scanning/1](https://github.com/pagopa/clamav-rest-service/security/code-scanning/1)

In general, the fix is to explicitly declare a `permissions:` block with the narrowest set of privileges needed for the workflow to run. Since this workflow only validates pull request titles and does not modify repository contents, it should need at most read access to repository contents and pull request metadata.

The best single fix without changing existing functionality is to add a `permissions:` block at the workflow root (top level, alongside `name:` and `on:`) so it applies to all jobs. A minimal and appropriate configuration here is `contents: read` to allow reading the repository and `pull-requests: read` to inspect PR metadata. No imports or additional methods are needed, because this is a YAML configuration change within `.github/workflows/pr-title.yml`.

Concretely, edit `.github/workflows/pr-title.yml` to insert a `permissions:` section after the `name: "Validate PR title"` line (line 1) and before the `on:` block (line 3). The rest of the workflow remains unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
