### PR TITLE
breaking: Remove input_file in scan response

### DIFF
--- a/clamav_rest_service/__init__.py
+++ b/clamav_rest_service/__init__.py
@@ -22,7 +22,6 @@ The following variables are accepted:
 import logging
 
 from flask import Flask, jsonify, render_template, request
-from flask.logging import default_handler
 from flask_swagger import swagger
 from werkzeug.exceptions import HTTPException
 
@@ -182,10 +181,6 @@ def scan_file():
               type: string
               description: Status of the scanning {OK,FOUND,ERROR}
               example: FOUND
-            input_file:
-              type: string
-              description: Input file that was scanned
-              example: myfile.txt
             virus:
               type: string
               description: Virus found, if any
@@ -224,10 +219,6 @@ def scan_file():
     # pack the response
     resp_body = {
         "status": result.status.value,
-        # the input_file is always "stream" as returned by clamd
-        # INSTREAM command, use what the client told us about the file
-        # for a more significative response to the user "input_file":
-        "input_file": filename,
         "virus": result.virus,
         "details": result.details,
         "error": result.err_msg,


### PR DESCRIPTION
Remove `input_file` property in the scanning response. 

This was based on user input, this triggered [security alert](https://github.com/pagopa/clamav-rest-service/security/code-scanning/3) (although it shouldn't be a problem in any likely case).

The property is removed altogether, as it was not especially useful in the beginning.

> [!WARNING]
> This is *technically* a breaking change, but that parameter was probably useless and never used